### PR TITLE
Ad Exchange Buyer APIs

### DIFF
--- a/CSharp/Google.Apis.RealTimeBidding.Examples.csproj
+++ b/CSharp/Google.Apis.RealTimeBidding.Examples.csproj
@@ -16,6 +16,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Google.Apis.RealTimeBidding.Examples.Program</StartupObject>
+    <!-- Run FirstApiRequest by uncommenting the next line and commenting the previous line.-->
+    <!--<StartupObject>Google.Apis.RealTimeBidding.Examples.v1.FirstApiRequest</StartupObject>-->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Apis" Version="1.49.0" />

--- a/CSharp/v1/FirstApiRequest.cs
+++ b/CSharp/v1/FirstApiRequest.cs
@@ -1,0 +1,84 @@
+/* Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Apis.RealTimeBidding.v1;
+using Google.Apis.RealTimeBidding.v1.Data;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Json;
+using Google.Apis.Services;
+
+using System;
+using System.Collections.Generic;
+
+namespace Google.Apis.RealTimeBidding.Examples.v1
+{
+    /// <summary>
+    /// Self contained sample to return a list of creatives for a given buyer account.
+    /// Primarily used by the Getting Started guide:
+    /// https://developers.google.com/authorized-buyers/apis/getting_started
+    ///
+    /// Note: To run this sample, you will need to configure it as the StartupObject in
+    /// Google.Apis.RealTimeBidding.Examples.csproj.
+    /// </summary>
+    internal class FirstApiRequest
+    {
+        private static void Main(string[] args)
+        {
+            // See the README.md for details of these fields.
+            // Retrieved from https://console.developers.google.com
+            var ServiceKeyFilePath = "PATH TO JSON KEY FILE HERE";
+
+            // Name of the buyer resource for which the API call is being made.
+            var buyerName = "INSERT_BUYER_RESOURCE_NAME_HERE";
+
+            // Retrieve credential parameters from the key JSON file.
+            var credentialParameters = NewtonsoftJsonSerializer.Instance
+                .Deserialize<JsonCredentialParameters>(
+                    System.IO.File.ReadAllText(ServiceKeyFilePath));
+
+            // Create the credentials.
+            var credentialInitializer = new ServiceAccountCredential.Initializer(
+                    credentialParameters.ClientEmail)
+                {
+                    Scopes = new[] { RealTimeBiddingService.Scope.RealtimeBidding }
+                }.FromPrivateKey(credentialParameters.PrivateKey);
+
+            var oAuth2Credentials = new ServiceAccountCredential(credentialInitializer);
+
+            // Use the credentials to create a client for the API service.
+            var serviceInitializer = new BaseClientService.Initializer
+                {
+                    HttpClientInitializer = oAuth2Credentials,
+                    ApplicationName = "FirstAPICall"
+                };
+
+            var realtimebidding = new RealTimeBiddingService(serviceInitializer);
+
+            // Call the buyers.creatives.list method to list creatives for the given buyer.
+            BuyersResource.CreativesResource.ListRequest request =
+                realtimebidding.Buyers.Creatives.List(buyerName);
+            request.View = BuyersResource.CreativesResource.ListRequest.ViewEnum.FULL;
+
+            IList<Creative> creatives = request.Execute().Creatives;
+
+            foreach (Creative creative in creatives)
+            {
+                Console.WriteLine("* Creative name: {0}", creative.Name);
+            }
+
+            Console.ReadLine();
+        }
+    }
+}

--- a/java/src/main/java/com/google/api/services/samples/authorizedbuyers/realtimebidding/v1/FirstApiRequest.java
+++ b/java/src/main/java/com/google/api/services/samples/authorizedbuyers/realtimebidding/v1/FirstApiRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.services.samples.authorizedbuyers.realtimebidding.v1;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.realtimebidding.v1.RealTimeBidding;
+import com.google.api.services.realtimebidding.v1.RealTimeBiddingScopes;
+import com.google.api.services.realtimebidding.v1.model.Creative;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A sample application that authenticates and runs a request against the
+ * Authorized Buyers Real-time Bidding API.
+ */
+public class FirstApiRequest {
+
+  /**
+   * Be sure to specify the name of your application. If the application name is
+   * {@code null} or blank, the application will log a warning. Suggested format
+   * is "MyCompany-ProductName/1.0".
+   */
+  private static final String APPLICATION_NAME = "APPLICATION_NAME_HERE";
+
+  // Full path to JSON Key file - include file name.
+  private static final java.io.File JSON_FILE =
+      new java.io.File("INSERT_PATH_TO_JSON_FILE");
+
+  // Name of the buyer resource for which the API call is being made.
+  private static final String BUYER_NAME = "INSERT_BUYER_RESOURCE_NAME";
+
+  // Global instance of the HTTP transport.
+  private static HttpTransport httpTransport;
+
+  // Global instance of the JSON factory.
+  private static final JsonFactory jsonFactory =
+      JacksonFactory.getDefaultInstance();
+
+
+  public static void main(String[] args) throws Exception {
+    // Create credentials using the JSON key file.
+    GoogleCredentials credentials = null;
+
+    try (FileInputStream serviceAccountStream = new FileInputStream((JSON_FILE))) {
+      Set<String> scopes = new HashSet<>(RealTimeBiddingScopes.all());
+      credentials = ServiceAccountCredentials
+          .fromStream(serviceAccountStream)
+          .createScoped(scopes);
+    } catch(IOException ex) {
+      System.out.println("Can't complete authorization step. Did you specify a JSON key file?");
+      System.out.println(ex);
+      System.exit(1);
+    }
+
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(credentials);
+    httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+
+    // Use the credentials to create a client for the API service.
+    RealTimeBidding realtimeBidding = new RealTimeBidding.Builder(httpTransport,
+        jsonFactory, requestInitializer).setApplicationName(APPLICATION_NAME)
+        .build();
+
+    // Call the buyers.creatives.list method to get a list of creatives for the given buyer.
+    List<Creative> creatives = realtimeBidding.buyers().creatives()
+        .list(BUYER_NAME)
+        .setView("FULL")
+        .execute().getCreatives();
+
+    if (creatives != null && creatives.size() > 0) {
+      System.out.printf("Listing of creatives associated with buyer '%s'%n", BUYER_NAME);
+      for (Creative creative : creatives) {
+        System.out.printf("* Creative name: %s\n", creative.getName());
+      }
+    } else {
+      System.out.printf("No creatives were found that were associated with buyer '%s'%n.",
+          BUYER_NAME);
+    }
+  }
+}
+

--- a/php/Examples/V1/FirstApiRequest.php
+++ b/php/Examples/V1/FirstApiRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Sample application that authenticates and makes an API request.
+ */
+
+/**
+ * Provide path to client library. See README.md for details.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Google_Service_RealTimeBidding;
+
+
+session_start();
+
+/**
+ * You can retrieve this file from the Google Developers Console.
+ *
+ * See README.md for details.
+ */
+$keyFileLocation = "INSERT_PATH_TO_JSON_KEYFILE";
+
+/**
+ * Name of the buyer resource for which the API call is being made.
+ */
+$buyerName = "INSERT_BUYER_RESOURCE_NAME";
+
+if ($keyFileLocation === 'INSERT_PATH_TO_JSON_KEYFILE') {
+    print "WARNING: Authorization details not provided!\n";
+    exit(1);
+}
+
+$client = new Google_Client();
+$client->setApplicationName('Authorized Buyers Real-time Bidding API PHP Samples');
+
+$service = new Google_Service_RealTimeBidding($client);
+
+$client->setAuthConfig($keyFileLocation);
+$client->addScope('https://www.googleapis.com/auth/realtime-bidding');
+
+if ($client->isAccessTokenExpired()) {
+    $client->refreshTokenWithAssertion();
+}
+
+if ($client->getAccessToken()) {
+    // Configure query parameters for the API call.
+    $queryParams = [
+        'view' => 'FULL'
+    ];
+
+    // Call the buyers.creatives.list method to get a list of creatives for the given buyer.
+    $result = $service->buyers_creatives->listBuyersCreatives($buyerName, $queryParams);
+
+    print "Creatives associated with buyer account\n";
+    if (empty($result['creatives'])) {
+        print "No creatives found\n";
+        return;
+    } else {
+        foreach ($result['creatives'] as $creative) {
+            print_r($creative);
+        }
+    }
+}

--- a/python/v1/first_api_request.py
+++ b/python/v1/first_api_request.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample application that authenticates and makes an API request."""
+
+import pprint
+from googleapiclient.discovery import build
+from google.oauth2 import service_account
+
+# A Service Account key file can be generated via the Google Developers
+# Console.
+KEY_FILE = 'PATH_TO_JSON_KEY_FILE'  # Path to Service Account JSON key file.
+
+# Authorized Buyers Real-time Bidding API authorization scope.
+SCOPE = 'https://www.googleapis.com/auth/realtime-bidding'
+VERSION = 'v1'  # Version of Authorized Buyers Real-time Bidding API to use.
+
+# Name of the buyer resource for which the API call is being made.
+BUYER_NAME = 'BUYER_RESOURCE_NAME'
+
+
+def main():
+  # Create credentials using the Service Account JSON key file.
+  credentials = service_account.Credentials.from_service_account_file(
+      KEY_FILE, scopes=[SCOPE])
+
+  # Build a client for the realtimebidding API service.
+  realtimebidding = build('realtimebidding', VERSION, credentials=credentials)
+
+  # Call the buyers.creatives.list method to get a list of creatives for the
+  # given buyer.
+  request = realtimebidding.buyers().creatives().list(parent=BUYER_NAME)
+
+  pprint.pprint(request.execute())
+
+
+if __name__ == '__main__':
+  main()
+

--- a/ruby/v1/first_api_request.rb
+++ b/ruby/v1/first_api_request.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# Encoding: utf-8
+#
+# Copyright:: Copyright 2020 Google LLC
+#
+# License:: Licensed under the Apache License, Version 2.0 (the "License");
+#           you may not use this file except in compliance with the License.
+#           You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#           Unless required by applicable law or agreed to in writing, software
+#           distributed under the License is distributed on an "AS IS" BASIS,
+#           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#           implied.
+#           See the License for the specific language governing permissions and
+#           limitations under the License.
+#
+# Sample application that authenticates and makes an API request.
+
+require 'google/apis/realtimebidding_v1'
+require 'googleauth/service_account'
+
+# You can download the JSON keyfile used for authentication from the Google
+# Developers Console.
+KEY_FILE = 'path_to_key'  # Path to JSON file containing your private key.
+
+# Name of the buyer resource for which the API call is being made.
+BUYER_NAME = 'insert_buyer_resource_name'
+
+
+def first_api_request()
+  # Create credentials using the JSON key file.
+  auth_options = {
+    :json_key_io => File.open(KEY_FILE, "r"),
+    :scope => 'https://www.googleapis.com/auth/realtime-bidding'
+  }
+
+  oauth_credentials = Google::Auth::ServiceAccountCredentials.make_creds(
+    options=auth_options
+  )
+
+  # Create the service and set credentials
+  realtimebidding = (
+    Google::Apis::RealtimebiddingV1::RealtimeBiddingService.new
+  )
+  realtimebidding.authorization = oauth_credentials
+  realtimebidding.authorization.fetch_access_token!
+
+  begin
+    # Call the buyers.creatives.list method to get list of creatives for given buyer.
+    creatives_list = realtimebidding.list_buyer_creatives(
+        BUYER_NAME, view: 'FULL')
+
+    if creatives_list.creatives.any?
+      puts "Found the following creatives for buyer '%s':" % BUYER_NAME
+      creatives_list.creatives.each do |creative|
+        puts "* Creative name: #{creative.name}"
+      end
+    else
+      puts "No creatives were found that were associated with buyer '%s'" % BUYER_NAME
+    end
+  rescue Google::Apis::ServerError => e
+    raise "The following server error occured:\n%s" % e.message
+  rescue Google::Apis::ClientError => e
+    raise "Invalid client request:\n%s" % e.message
+  rescue Google::Apis::AuthorizationError => e
+    raise "Authorization error occured:\n%s" % e.message
+  end
+end
+
+if __FILE__ == $0
+  begin
+    first_api_request()
+  end
+end
+


### PR DESCRIPTION
**Prepare for authorization**
Complete the following steps to prepare for authentication using OAuth 2.0. The API supports many types of credentials; for this example we'll use a service account.

1. Go to the Google API Console Enabled APIs page.
2. From the project drop-down, select a project or create a new one.
3. In the list of Enabled APIs, make sure Ad Exchange Buyer API is listed. If it's not listed, click the Google APIs tab, search for and select the Ad Exchange Buyer API, and click Enable API.
4. Next, in the sidebar on the left select Credentials.
5. Select the Create credentials drop-down, then choose Service account key.
6. In the Service account drop-down, choose New service account.
7. Enter a Name for the service account. The service account ID is automatically generated from the name and project name.
8. Note the service account ID: you'll need it to grant access to the new service account in the Authorized Buyers UI in step 11.
9. Choose a Key type, either the recommended JSON file, or P12 if backward compatibility with code using P12 format is needed.
10. Click Create. The JSON or P12 file with the account's public/private key pair is saved to your Downloads folder. Keep the generated JSON or P12 file in a safe place.
11. You must grant the service account access in the Authorized Buyers UI for it to work. Select Settings > Account Settings, then choose User Management > Account Users, and click +Service Account. Enter the service account ID you noted above in step 8. This creates a new user with the service account role.

[Source ](https://developers.google.com/authorized-buyers/apis/guides/start#prepare-for-authorization);
https://developers.google.com/authorized-buyers/apis/guides/start#prepare-for-authorization